### PR TITLE
update filesystem permission to `home`

### DIFF
--- a/com.tencent.WeChat.yaml
+++ b/com.tencent.WeChat.yaml
@@ -19,7 +19,7 @@ finish-args:
   # Uses legacy StatusNotifier implementation
   - --own-name=org.kde.*
   # Files
-  - --filesystem=xdg-download
+  - --filesystem=home
   - --persist=.xwechat
   - --persist=xwechat_files
   # Hidpi scale


### PR DESCRIPTION
The grant of access permission to `home` directory can make file transfer more convenient.