### PR TITLE
add x-checker-data for wechat.deb

### DIFF
--- a/com.tencent.WeChat.yaml
+++ b/com.tencent.WeChat.yaml
@@ -97,3 +97,6 @@ modules:
         url: https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_x86_64.deb
         sha256: 0e2834310e1d321da841a4cde9c657d9c086c5ee8c82d09e47eab53629a5038f
         size: 203260252
+        x-checker-data:
+          type: rotating-url
+          url: https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_x86_64.deb


### PR DESCRIPTION
I have tested this. It downloads the wechat.deb file, checks its SHA-256 hash, and compares it with the older version, but it will not update version in metainfo.