### PR TITLE
Disable coredump

### DIFF
--- a/wechat.sh
+++ b/wechat.sh
@@ -12,4 +12,6 @@ setup_ime_env() {
 
 setup_ime_env
 
+ulimit -c 0
+
 exec /app/extra/wechat/wechat "$@"


### PR DESCRIPTION
It crashes sometimes. But we don't have source for it. The coredump is useless.