### PR TITLE
Clear execstack from shared libraries which banned by SELinux

### DIFF
--- a/com.tencent.WeChat.yaml
+++ b/com.tencent.WeChat.yaml
@@ -55,6 +55,15 @@ modules:
         url: https://download.osgeo.org/libtiff/tiff-4.4.0.tar.gz
         sha256: 917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed
 
+  # Remove execstack from shared libraries
+  - name: patchelf
+    sources:
+      - type: archive
+        url: https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0.tar.gz
+        sha256: 64de10e4c6b8b8379db7e87f58030f336ea747c0515f381132e810dbf84a86e7
+    cleanup:
+      - /share
+
   - name: wechat
     buildsystem: simple
     build-commands:
@@ -70,6 +79,7 @@ modules:
           - bsdtar -O -xf wechat.deb data.* | bsdtar --no-same-owner -xf -
           - mv opt/wechat wechat
           - rm -rf wechat.deb usr opt
+          - patchelf --clear-execstack wechat/libandromeda.so wechat/libowl.so wechat/libvoipCodec.so
         dest-filename: apply_extra
 
       - type: file


### PR DESCRIPTION
https://github.com/web1n/wechat-universal-flatpak/issues/81