### PR TITLE
修复更新到4.1.13时提示的deb大小错误

### DIFF
--- a/com.tencent.WeChat.yaml
+++ b/com.tencent.WeChat.yaml
@@ -101,11 +101,11 @@ modules:
         only-arches: [x86_64]
         url: https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_x86_64.deb
         sha256: 869a8156318e2275237c280a637cb86ce7bd427ddb95864699b21c7f3ce64a29
-        size: 221182460
+        size: 211596124
 
       - type: extra-data
         filename: wechat.deb
         only-arches: [aarch64]
         url: https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_arm64.deb
         sha256: 32f4116a6964f570ba2441046a9094fb5b726398bead4e91fedee52a5215b351
-        size: 196015840
+        size: 188395020


### PR DESCRIPTION
Adjusted WeChat package sizes for x86_64 and aarch64 in YAML.
<img width="1441" height="1057" alt="图片" src="https://github.com/user-attachments/assets/780e5ad5-d60e-4212-b298-583a3b980ba5" />
<img width="1441" height="1057" alt="图片" src="https://github.com/user-attachments/assets/0cc1c78b-dc20-4fdc-aba6-431839a6c1d3" />
