### PR TITLE
fix: set LC_NUMERIC=C to prevent invisible UI elements on non-English locales

### DIFF
--- a/wechat.sh
+++ b/wechat.sh
@@ -12,6 +12,8 @@ setup_ime_env() {
 
 setup_ime_env
 
+export LC_NUMERIC=C
+
 ulimit -c 0
 
 exec /app/extra/wechat/wechat "$@"


### PR DESCRIPTION
## Problem
On systems where the locale uses a comma as the decimal separator (e.g. `pl_PL.UTF-8`, `de_DE.UTF-8`, `fr_FR.UTF-8`, `pt_BR.UTF-8`), WeChat's UI fails to render buttons, icons, text bubble colors, and other graphical elements. The application window appears mostly blank or broken.

This is caused by WeChat's Qt/QML parser misinterpreting numeric values in styles when the locale does not use a dot as the decimal separator.

## Solution
Set `LC_NUMERIC=C` in the launcher script (`wechat.sh`) before executing the WeChat binary. This forces the C locale for numeric formatting while preserving all other locale settings (language, date format, etc.).

## Testing
- [x] Built locally with `flatpak-builder`
- [x] Tested on CachyOS (Arch-based, locale `pl_PL.UTF-8`)
- [x] UI renders correctly: buttons, icons, chat bubble colors, and sidebar icons are all visible